### PR TITLE
[USX-1422] Remove production url from servers

### DIFF
--- a/apix_documentation_swagger_v3.yaml
+++ b/apix_documentation_swagger_v3.yaml
@@ -70,13 +70,16 @@ info:
         * Do not send real credentials to the Sandbox
 
       To make requests to the sandbox environment, use the following URL:
-        `https://apix.casiregalii.com`
+        `https://apix.staging.arcusapi.com`
 
     * __Production__. Once you have completed all the necessary tests on the
     sandbox, contact us to receive your production keys.
 
       To make requests to the production environment, use the following URL:
-        `https://apix.regalii.com`
+        `https://apix.arcusapi.com`
+
+      __NOTE:__ For security reasons, it's not possible to make production
+      requests through our dynamic documentation.
 
     ---
 
@@ -477,10 +480,8 @@ info:
       resource in the sandbox.
 
 servers:
-  - url: https://apix.casiregalii.com
+  - url: https://apix.staging.arcusapi.com
     description: Sandbox, Mock Credentials; Mock Data
-  - url: https://apix.regalii.com
-    description: Production, Real Credentials; Real Data
 
 tags:
   - name: Common

--- a/apix_documentation_swagger_v4.yaml
+++ b/apix_documentation_swagger_v4.yaml
@@ -81,6 +81,9 @@ info:
       To make requests to the production environment, use the following URL:
         `https://apix.arcusapi.com`
 
+      __NOTE:__ For security reasons, it's not possible to make production
+      requests through our dynamic documentation.
+
     ---
 
     # Security
@@ -405,8 +408,6 @@ info:
 servers:
   - url: https://apix.staging.arcusapi.com
     description: Sandbox, Mock Credentials; Mock Data
-  - url: https://apix.arcusapi.com
-    description: Production, Real Credentials; Real Data
 
 tags:
   - name: Common


### PR DESCRIPTION
Removes production url from documentation's servers and adds note of why it's not accessible.
Updates urls in v3.2

Jira: https://arcusfi.atlassian.net/browse/USX-1422

![captura de pantalla 2018-09-24 a la s 16 48 54](https://user-images.githubusercontent.com/8188432/45981186-c369b400-c019-11e8-8291-75e72bc174f1.png)
