### PR TITLE
Set the correct accept header for all v3 endpoints

### DIFF
--- a/apix_documentation_swagger_v3.yaml
+++ b/apix_documentation_swagger_v3.yaml
@@ -1284,7 +1284,7 @@ paths:
         200:
           description: successful response
           content:
-            application/json:
+            application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/Transaction'
 
@@ -1311,7 +1311,7 @@ paths:
         200:
           description: successful response
           content:
-            application/json:
+            application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/Transaction'
 


### PR DESCRIPTION
We recently realized that the GET/transactions/{id} endpoint was failing because the accept header was set incorrectly.

The DELETE/transactions/{id} had the same issue, though this fix will not be enough to make it work (because of CORS limitations)

https://arcusfi.atlassian.net/browse/USX-1566