### PR TITLE
Update documentation for DELETE /bill/:id endpoint

### DIFF
--- a/apix_documentation_swagger_v3.yaml
+++ b/apix_documentation_swagger_v3.yaml
@@ -853,12 +853,8 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        204:
           description: successful response
-          content:
-            application/vnd.regalii.v3.2+json:
-              schema:
-                $ref: '#/components/schemas/Bill'
   /bills/{id}/refresh:
     post:
       tags:


### PR DESCRIPTION
Changed from 200 (ok) to 204 (no content) to indicate the succesful deletion of a Bill