### PR TITLE
Add DELETE migration endpoint

### DIFF
--- a/apix_documentation_swagger_v3.yaml
+++ b/apix_documentation_swagger_v3.yaml
@@ -860,8 +860,6 @@ paths:
     delete:
       tags:
         - xData
-      servers:
-        - url: https://apix.casiregalii.com
       summary: Deletes a specific bill
       description: This endpoint deletes a specific bill
       operationId: deleteBill
@@ -1613,6 +1611,22 @@ paths:
             application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/Migration'
+    delete:
+      tags:
+        - xChange
+      summary: Deletes a specific migration
+      description: This endpoint deletes a specific migration
+      operationId: deleteMigration
+      parameters:
+        - name: id
+          in: path
+          description: UUID of the migration to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        204:
+          description: successful response
 
 components:
   securitySchemes:

--- a/apix_documentation_swagger_v4.yaml
+++ b/apix_documentation_swagger_v4.yaml
@@ -926,7 +926,6 @@ paths:
                   data:
                     allOf:
                       - $ref: '#/components/schemas/Migration'
-
                 example:
                   data:
                     id: b4aa7d78-6f16-4ddd-887d-9f5c0b730a26
@@ -938,6 +937,24 @@ paths:
                       error:
                         code: InvalidCredentials
                         detail: Invalid login or password
+
+    delete:
+      tags:
+        - xChange
+      summary: Deletes the data associated with a specific migration
+      description: This endpoint deletes the data associated with a specific
+        migration
+      operationId: deleteMigration
+      parameters:
+        - name: id
+          in: path
+          description: UUID of the migration to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        204:
+          description: successful response
 
   /migrations/{id}/challenges:
     get:


### PR DESCRIPTION
*What's this PR do?*
Adds description for DELETE/migration/{id} endpoint both in v3 and v4

*What are the relevant tickets?*
- Closes ENGR-111

NOTE: This should be merged only after the feature is actually accessible @jdsampayo 
