### PR TITLE
Engr 448 include validation errors for x pay

### DIFF
--- a/apix_documentation_swagger_v3.yaml
+++ b/apix_documentation_swagger_v3.yaml
@@ -1315,7 +1315,12 @@ paths:
             application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/Unauthorized'
-
+        422:
+          description: unprocessable entity response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/UnprocessableEntity'
     get:
       tags:
         - xPay
@@ -1495,6 +1500,17 @@ paths:
             application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/NotFound'
+        422:
+          description: unprocessable entity response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                example:
+                  message: 'Only on_hold transactions can be updated!'
 
     delete:
       tags:
@@ -2581,3 +2597,12 @@ components:
           type: string
       example:
         message: Not found
+
+    UnprocessableEntity:
+      type: object
+      properties:
+        message:
+          type: string
+      example:
+        message: 'param is missing or the value is empty: amount'
+        

--- a/apix_documentation_swagger_v3.yaml
+++ b/apix_documentation_swagger_v3.yaml
@@ -1081,6 +1081,27 @@ paths:
                   address:
                     description: xPay biller's address
                     type: array
+                    items:
+                      type: object
+                      properties:
+                        city:
+                          type: string
+                        state:
+                          type: string
+                        country:
+                          type: string
+                        address1:
+                          type: string
+                        address2:
+                          type: string
+                        eff_date:
+                          type: string
+                        external_id:
+                          type: string
+                        postal_code:
+                          type: string
+                        address_type:
+                          type: string
                   masks:
                     description: This array of objects describes the different
                       formats that an account_number of this biller can have
@@ -1101,6 +1122,8 @@ paths:
                           type: string
                         descriptions:
                           type: array
+                          items:
+                            type: object
                 example:
                   rpps_billers:
                     - id: 692b45ea-7369-4232-bdd6-2bd662fe1ebd
@@ -1158,6 +1181,14 @@ paths:
                           external_id: 343038
                           mask_format: ###-###@
                           descriptions: []
+
+        401:
+          description: unauthorized response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/Unauthorized'
+
   /transactions:
     post:
       tags:
@@ -1278,6 +1309,12 @@ paths:
             application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/Transaction'
+        401:
+          description: unauthorized response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/Unauthorized'
 
     get:
       tags:
@@ -1360,6 +1397,14 @@ paths:
                       updated_at: '2018-04-06T14:49:12.830Z'
                       error_code: null
                       error_message: null
+
+        401:
+          description: unauthorized response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/Unauthorized'
+
   /transactions/{id}:
     get:
       tags:
@@ -1382,6 +1427,12 @@ paths:
             application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/Transaction'
+        401:
+          description: unauthorized response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/Unauthorized'
 
     patch:
       tags:
@@ -1426,6 +1477,12 @@ paths:
             application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/Transaction'
+        401:
+          description: unauthorized response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/Unauthorized'
 
     delete:
       tags:
@@ -1457,6 +1514,12 @@ paths:
             application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/Transaction'
+        401:
+          description: unauthorized response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/Unauthorized'
 
   /transactions/{id}/check:
     get:
@@ -1480,6 +1543,12 @@ paths:
             application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/CheckTransactionSerialized'
+        401:
+          description: unauthorized response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/Unauthorized'
 
   /transactions/{id}/check.pdf:
     get:
@@ -1499,6 +1568,12 @@ paths:
       responses:
         200:
           description: OK
+        401:
+          description: unauthorized response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/Unauthorized'
 
 
   /addresses:
@@ -1552,6 +1627,12 @@ paths:
                 address_city: New York
                 address_state: NY
                 address_zip: 10001
+        401:
+          description: unauthorized response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/Unauthorized'
 
     get:
       tags:
@@ -1573,6 +1654,12 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/CheckAddress'
+        401:
+          description: unauthorized response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/Unauthorized'
 
   /addresses/{id}:
     get:
@@ -1596,6 +1683,12 @@ paths:
             application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/CheckAddress'
+        401:
+          description: unauthorized response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/Unauthorized'
 
     delete:
       tags:
@@ -1620,6 +1713,12 @@ paths:
             application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/CheckAddress'
+        401:
+          description: unauthorized response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/Unauthorized'
 
   /migrations:
     post:
@@ -2425,3 +2524,12 @@ components:
         address_zip:
           type: string
           example: 10001
+
+    Unauthorized:
+      type: object
+      properties:
+        message:
+          type: string
+      example:
+        message: Unauthorized
+    

--- a/apix_documentation_swagger_v3.yaml
+++ b/apix_documentation_swagger_v3.yaml
@@ -1433,6 +1433,12 @@ paths:
             application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/Unauthorized'
+        404:
+          description: not found response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
 
     patch:
       tags:
@@ -1483,6 +1489,12 @@ paths:
             application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/Unauthorized'
+        404:
+          description: not found response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
 
     delete:
       tags:
@@ -1520,6 +1532,12 @@ paths:
             application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/Unauthorized'
+        404:
+          description: not found response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
 
   /transactions/{id}/check:
     get:
@@ -1549,6 +1567,12 @@ paths:
             application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/Unauthorized'
+        404:
+          description: not found response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
 
   /transactions/{id}/check.pdf:
     get:
@@ -1574,7 +1598,12 @@ paths:
             application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/Unauthorized'
-
+        404:
+          description: not found response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
 
   /addresses:
     post:
@@ -1689,6 +1718,12 @@ paths:
             application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/Unauthorized'
+        404:
+          description: not found response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
 
     delete:
       tags:
@@ -1719,6 +1754,12 @@ paths:
             application/vnd.regalii.v3.2+json:
               schema:
                 $ref: '#/components/schemas/Unauthorized'
+        404:
+          description: not found response
+          content:
+            application/vnd.regalii.v3.2+json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
 
   /migrations:
     post:
@@ -2532,4 +2573,11 @@ components:
           type: string
       example:
         message: Unauthorized
-    
+
+    NotFound:
+      type: object
+      properties:
+        message:
+          type: string
+      example:
+        message: Not found


### PR DESCRIPTION
#### What's this PR do?
adds different possible common errors to example responses for xpay end points

#### Where should the reviewer start?
see the images

#### How should this be manually tested?
  1. Step 1
  2. Step 2

#### Any background context you want to provide?
Marqeta mentioned that it would be helpful for them to have a comprehensive list of validation errors returned by our API. E.g.: "Validation failed: Account number must be a valid card number"

#### What are the relevant tickets?
  - Closes [#ENGR-448](https://arcusfi.atlassian.net/browse/ENGR-448)

#### Screenshots (if appropriate)
<img width="936" alt="Captura de Pantalla 2019-04-04 a la(s) 14 53 50" src="https://user-images.githubusercontent.com/3043849/55587854-92192180-56e9-11e9-83d5-b8fa255fc1eb.png">
<img width="974" alt="Captura de Pantalla 2019-04-04 a la(s) 14 54 06" src="https://user-images.githubusercontent.com/3043849/55587855-92192180-56e9-11e9-97f9-1c519deac6e9.png">
<img width="993" alt="Captura de Pantalla 2019-04-04 a la(s) 14 54 17" src="https://user-images.githubusercontent.com/3043849/55587856-92192180-56e9-11e9-9b30-c109e2a6f1d6.png">


#### Questions:
- Question 1
